### PR TITLE
feat: 회원가입 로직 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ out/
 .DS_Store
 
 logs/
+
+# application.properties 파일 무시
+application.properties

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'jakarta.validation:jakarta.validation-api:3.0.2'
+	implementation 'org.hibernate.validator:hibernate-validator:8.0.1.Final'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -35,8 +35,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	implementation 'jakarta.validation:jakarta.validation-api:3.0.2'
-	implementation 'org.hibernate.validator:hibernate-validator:8.0.1.Final'
+
+	// 유효성 검사를 위한 의존성
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sixjeon/storey/StoreyApplication.java
+++ b/src/main/java/com/sixjeon/storey/StoreyApplication.java
@@ -1,9 +1,12 @@
 package com.sixjeon.storey;
 
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class StoreyApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/sixjeon/storey/domain/auth/entity/Role.java
+++ b/src/main/java/com/sixjeon/storey/domain/auth/entity/Role.java
@@ -1,0 +1,5 @@
+package com.sixjeon.storey.domain.auth.entity;
+
+public enum Role {
+    OWNER, USER
+}

--- a/src/main/java/com/sixjeon/storey/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/sixjeon/storey/domain/auth/exception/AuthErrorCode.java
@@ -7,7 +7,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum AuthErrorCode implements BaseResponseCode {
-    AUTH_DUPLICATE_LOGINID_409("AUTH_DULICATE_LOGINID_409",409,"이미 존재하는 아이디입니다.");
+    AUTH_DUPLICATE_LOGINID_409("AUTH_DULICATE_LOGINID_409",409,"이미 존재하는 아이디입니다."),
+    ROLE_INVALID_400("ROLE_INVALID_400",400,"유효하지 않은 사용자 유형입니다.");
 
     private final String code;
     private final int httpStatus;

--- a/src/main/java/com/sixjeon/storey/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/sixjeon/storey/domain/auth/exception/AuthErrorCode.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum AuthErrorCode implements BaseResponseCode {
     AUTH_DUPLICATE_LOGINID_409("AUTH_DULICATE_LOGINID_409",409,"이미 존재하는 아이디입니다."),
+    AUTH_DUPLICATE_PHONENUMBER_409("AUTH_DUPLICATE_PHONENUMBER_409",409,"이미 존재하는 전화번호 입니다."),
     ROLE_INVALID_400("ROLE_INVALID_400",400,"유효하지 않은 사용자 유형입니다.");
 
     private final String code;

--- a/src/main/java/com/sixjeon/storey/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/sixjeon/storey/domain/auth/exception/AuthErrorCode.java
@@ -1,0 +1,15 @@
+package com.sixjeon.storey.domain.auth.exception;
+
+import com.sixjeon.storey.global.response.code.BaseResponseCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum AuthErrorCode implements BaseResponseCode {
+    AUTH_DUPLICATE_LOGINID_409("AUTH_DULICATE_LOGINID_409",409,"이미 존재하는 아이디입니다.");
+
+    private final String code;
+    private final int httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/sixjeon/storey/domain/auth/exception/DuplicateLoginIdException.java
+++ b/src/main/java/com/sixjeon/storey/domain/auth/exception/DuplicateLoginIdException.java
@@ -1,0 +1,9 @@
+package com.sixjeon.storey.domain.auth.exception;
+
+import com.sixjeon.storey.global.exception.BaseException;
+
+public class DuplicateLoginIdException extends BaseException {
+    public DuplicateLoginIdException() {
+        super(AuthErrorCode.AUTH_DUPLICATE_LOGINID_409);
+    }
+}

--- a/src/main/java/com/sixjeon/storey/domain/auth/exception/DuplicatePhoneNumberException.java
+++ b/src/main/java/com/sixjeon/storey/domain/auth/exception/DuplicatePhoneNumberException.java
@@ -1,0 +1,9 @@
+package com.sixjeon.storey.domain.auth.exception;
+
+import com.sixjeon.storey.global.exception.BaseException;
+
+public class DuplicatePhoneNumberException extends BaseException {
+    public DuplicatePhoneNumberException() {
+        super(AuthErrorCode.AUTH_DUPLICATE_PHONENUMBER_409);
+    }
+}

--- a/src/main/java/com/sixjeon/storey/domain/auth/exception/InvalidRoleException.java
+++ b/src/main/java/com/sixjeon/storey/domain/auth/exception/InvalidRoleException.java
@@ -1,0 +1,10 @@
+package com.sixjeon.storey.domain.auth.exception;
+
+import com.sixjeon.storey.global.exception.BaseException;
+
+public class InvalidRoleException extends BaseException {
+    public InvalidRoleException() {
+      super(AuthErrorCode.ROLE_INVALID_400);
+
+    }
+}

--- a/src/main/java/com/sixjeon/storey/domain/auth/service/AuthService.java
+++ b/src/main/java/com/sixjeon/storey/domain/auth/service/AuthService.java
@@ -1,0 +1,8 @@
+package com.sixjeon.storey.domain.auth.service;
+
+import com.sixjeon.storey.domain.auth.web.dto.SignupReq;
+import com.sixjeon.storey.domain.auth.web.dto.SignupRes;
+
+public interface AuthService {
+    SignupRes signUp(SignupReq signupReq);
+}

--- a/src/main/java/com/sixjeon/storey/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/sixjeon/storey/domain/auth/service/AuthServiceImpl.java
@@ -1,0 +1,45 @@
+package com.sixjeon.storey.domain.auth.service;
+
+import com.sixjeon.storey.domain.auth.entity.Role;
+import com.sixjeon.storey.domain.auth.exception.InvalidRoleException;
+import com.sixjeon.storey.domain.auth.web.dto.SignupReq;
+import com.sixjeon.storey.domain.auth.web.dto.SignupRes;
+import com.sixjeon.storey.domain.owner.entity.Owner;
+import com.sixjeon.storey.domain.owner.service.OwnerService;
+import com.sixjeon.storey.domain.user.entity.User;
+import com.sixjeon.storey.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+    private final OwnerService ownerService;
+    private final UserService userService;
+
+
+    @Override
+    public SignupRes signUp(SignupReq signupReq) {
+        switch (signupReq.getRole()) {
+            case OWNER:
+                Owner owner = ownerService.createOwner(signupReq);
+
+                return new SignupRes(
+                        owner.getId(),
+                        owner.getLoginId(),
+                        owner.getPhoneNumber(),
+                        Role.OWNER
+                );
+            case USER:
+                User user = userService.createUser(signupReq);
+
+                return new SignupRes(
+                        user.getId(),
+                        user.getLoginId(),
+                        user.getPhoneNumber(),
+                        Role.USER);
+            default:
+                throw new InvalidRoleException();
+        }
+    }
+}

--- a/src/main/java/com/sixjeon/storey/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/sixjeon/storey/domain/auth/service/AuthServiceImpl.java
@@ -2,6 +2,7 @@ package com.sixjeon.storey.domain.auth.service;
 
 import com.sixjeon.storey.domain.auth.entity.Role;
 import com.sixjeon.storey.domain.auth.exception.DuplicateLoginIdException;
+import com.sixjeon.storey.domain.auth.exception.DuplicatePhoneNumberException;
 import com.sixjeon.storey.domain.auth.exception.InvalidRoleException;
 import com.sixjeon.storey.domain.auth.web.dto.SignupReq;
 import com.sixjeon.storey.domain.auth.web.dto.SignupRes;
@@ -28,6 +29,11 @@ public class AuthServiceImpl implements AuthService {
         // 아이디 중복 확인
         if (ownerRepository.existsByLoginId(signupReq.getLoginId()) || userRepository.existsByLoginId(signupReq.getLoginId())) {
             throw new DuplicateLoginIdException();
+        }
+        // 전화번호 중복 확인
+        if (ownerRepository.existsByPhoneNumber(signupReq.getPhoneNumber()) || userRepository.existsByPhoneNumber(signupReq.getPhoneNumber())) {
+            throw new DuplicatePhoneNumberException();
+
         }
         // String role을 Role enum로 변환
         Role role;

--- a/src/main/java/com/sixjeon/storey/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/sixjeon/storey/domain/auth/service/AuthServiceImpl.java
@@ -20,7 +20,16 @@ public class AuthServiceImpl implements AuthService {
 
     @Override
     public SignupRes signUp(SignupReq signupReq) {
-        switch (signupReq.getRole()) {
+        // String role을 Role enum로 변환
+        Role role;
+        try {
+            role = Role.valueOf(signupReq.getRole().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new InvalidRoleException();
+        }
+
+
+        switch (role) {
             case OWNER:
                 Owner owner = ownerService.createOwner(signupReq);
 

--- a/src/main/java/com/sixjeon/storey/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/sixjeon/storey/domain/auth/service/AuthServiceImpl.java
@@ -1,12 +1,15 @@
 package com.sixjeon.storey.domain.auth.service;
 
 import com.sixjeon.storey.domain.auth.entity.Role;
+import com.sixjeon.storey.domain.auth.exception.DuplicateLoginIdException;
 import com.sixjeon.storey.domain.auth.exception.InvalidRoleException;
 import com.sixjeon.storey.domain.auth.web.dto.SignupReq;
 import com.sixjeon.storey.domain.auth.web.dto.SignupRes;
 import com.sixjeon.storey.domain.owner.entity.Owner;
+import com.sixjeon.storey.domain.owner.repository.OwnerRepository;
 import com.sixjeon.storey.domain.owner.service.OwnerService;
 import com.sixjeon.storey.domain.user.entity.User;
+import com.sixjeon.storey.domain.user.repository.UserRepository;
 import com.sixjeon.storey.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,10 +19,16 @@ import org.springframework.stereotype.Service;
 public class AuthServiceImpl implements AuthService {
     private final OwnerService ownerService;
     private final UserService userService;
+    private final OwnerRepository ownerRepository;
+    private final UserRepository userRepository;
 
 
     @Override
     public SignupRes signUp(SignupReq signupReq) {
+        // 아이디 중복 확인
+        if (ownerRepository.existsByLoginId(signupReq.getLoginId()) || userRepository.existsByLoginId(signupReq.getLoginId())) {
+            throw new DuplicateLoginIdException();
+        }
         // String role을 Role enum로 변환
         Role role;
         try {

--- a/src/main/java/com/sixjeon/storey/domain/auth/web/controller/AuthController.java
+++ b/src/main/java/com/sixjeon/storey/domain/auth/web/controller/AuthController.java
@@ -1,0 +1,32 @@
+package com.sixjeon.storey.domain.auth.web.controller;
+
+import com.sixjeon.storey.domain.auth.service.AuthService;
+import com.sixjeon.storey.domain.auth.web.dto.SignupReq;
+import com.sixjeon.storey.domain.auth.web.dto.SignupRes;
+import com.sixjeon.storey.global.response.SuccessResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<SuccessResponse<?>> signUp(@Valid @RequestBody SignupReq signupReq) {
+        SignupRes signupRes = authService.signUp(signupReq);
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(SuccessResponse.created(signupRes));
+
+    }
+}

--- a/src/main/java/com/sixjeon/storey/domain/auth/web/dto/SignupReq.java
+++ b/src/main/java/com/sixjeon/storey/domain/auth/web/dto/SignupReq.java
@@ -1,0 +1,24 @@
+package com.sixjeon.storey.domain.auth.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SignupReq {
+
+    @NotBlank(message = "아이디는 필수 입력 값입니다.")
+    @Size(max = 12, message = "아이디는 12자 이내여야 합니다.")
+    @Pattern(regexp = "^[a-zA-Z0-9]*$", message = "아이디는 영문자와 숫자만 사용할 수 있습니다.")
+    private String loginId;
+
+    @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+    @Size(min = 8, max = 20, message = "비밀번호는 8~20자 사이여야 합니다.")
+    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[0-9]).*$", message = "비밀번호는 영문자와 숫자를 포함해야 합니다.")
+    private String password;
+
+    private String phoneNumber;
+}

--- a/src/main/java/com/sixjeon/storey/domain/auth/web/dto/SignupReq.java
+++ b/src/main/java/com/sixjeon/storey/domain/auth/web/dto/SignupReq.java
@@ -1,6 +1,7 @@
 package com.sixjeon.storey.domain.auth.web.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
@@ -22,6 +23,6 @@ public class SignupReq {
     private String password;
 
     private String phoneNumber;
-
-    private Role role;
+    // enum을 DTO에서 직접 받으면 Jackson이 잘못된 값의 예외 처리가 복잡해지므로 String으로 받음
+    private String role;
 }

--- a/src/main/java/com/sixjeon/storey/domain/auth/web/dto/SignupReq.java
+++ b/src/main/java/com/sixjeon/storey/domain/auth/web/dto/SignupReq.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import com.sixjeon.storey.domain.auth.entity.Role;
 
 @Getter
 @NoArgsConstructor
@@ -21,4 +22,6 @@ public class SignupReq {
     private String password;
 
     private String phoneNumber;
+
+    private Role role;
 }

--- a/src/main/java/com/sixjeon/storey/domain/auth/web/dto/SignupRes.java
+++ b/src/main/java/com/sixjeon/storey/domain/auth/web/dto/SignupRes.java
@@ -1,0 +1,11 @@
+package com.sixjeon.storey.domain.auth.web.dto;
+
+import com.sixjeon.storey.domain.auth.entity.Role;
+
+public record SignupRes(
+        Long id,
+        String loginId,
+        String phoneNumber,
+        Role role
+) {
+}

--- a/src/main/java/com/sixjeon/storey/domain/owner/entity/Owner.java
+++ b/src/main/java/com/sixjeon/storey/domain/owner/entity/Owner.java
@@ -1,0 +1,42 @@
+package com.sixjeon.storey.domain.owner.entity;
+
+import com.sixjeon.storey.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class Owner extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "owner_id")
+    private Long id;
+    // 사장님 이름 -> 회원가입 받을 때 입력받지 않으므로 nullable = true로 설정
+    @Column(name = "representative_name",nullable = true)
+    private String representativeName;
+
+    @Column(name = "login_id", nullable = false, unique = true)
+    private String loginId;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
+    @Column(name = "phone_number", nullable = false, unique = true)
+    private String phoneNumber;
+
+    @Builder
+    public Owner( String loginId, String password, String phoneNumber) {
+        this.loginId = loginId;
+        this.password = password;
+        this.phoneNumber = phoneNumber;
+    }
+
+
+
+}

--- a/src/main/java/com/sixjeon/storey/domain/owner/repository/OwnerRepository.java
+++ b/src/main/java/com/sixjeon/storey/domain/owner/repository/OwnerRepository.java
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface OwnerRepository extends JpaRepository<Owner, Long> {
     boolean existsByLoginId(String loginId);
+    boolean existsByPhoneNumber(String phoneNumber);
 }

--- a/src/main/java/com/sixjeon/storey/domain/owner/repository/OwnerRepository.java
+++ b/src/main/java/com/sixjeon/storey/domain/owner/repository/OwnerRepository.java
@@ -2,7 +2,9 @@ package com.sixjeon.storey.domain.owner.repository;
 
 import com.sixjeon.storey.domain.owner.entity.Owner;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface OwnerRepository extends JpaRepository<Owner, Long> {
     boolean existsByLoginId(String loginId);
 }

--- a/src/main/java/com/sixjeon/storey/domain/owner/repository/OwnerRepository.java
+++ b/src/main/java/com/sixjeon/storey/domain/owner/repository/OwnerRepository.java
@@ -1,0 +1,8 @@
+package com.sixjeon.storey.domain.owner.repository;
+
+import com.sixjeon.storey.domain.owner.entity.Owner;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OwnerRepository extends JpaRepository<Owner, Long> {
+    boolean existsByLoginId(String loginId);
+}

--- a/src/main/java/com/sixjeon/storey/domain/owner/service/OwnerService.java
+++ b/src/main/java/com/sixjeon/storey/domain/owner/service/OwnerService.java
@@ -1,0 +1,8 @@
+package com.sixjeon.storey.domain.owner.service;
+
+import com.sixjeon.storey.domain.auth.web.dto.SignupReq;
+import com.sixjeon.storey.domain.owner.entity.Owner;
+
+public interface OwnerService {
+    Owner createOwner(SignupReq signupReq);
+}

--- a/src/main/java/com/sixjeon/storey/domain/owner/service/OwnerServiceImpl.java
+++ b/src/main/java/com/sixjeon/storey/domain/owner/service/OwnerServiceImpl.java
@@ -18,9 +18,9 @@ public class OwnerServiceImpl implements OwnerService {
     @Override
     public Owner createOwner(SignupReq signupReq) {
 
-        if (ownerRepository.existsByLoginId(signupReq.getLoginId())) {
-            throw new DuplicateLoginIdException();
-        }
+//        if (ownerRepository.existsByLoginId(signupReq.getLoginId())) {
+//            throw new DuplicateLoginIdException();
+//        }
 
         Owner owner = Owner.builder()
                 .loginId(signupReq.getLoginId())

--- a/src/main/java/com/sixjeon/storey/domain/owner/service/OwnerServiceImpl.java
+++ b/src/main/java/com/sixjeon/storey/domain/owner/service/OwnerServiceImpl.java
@@ -1,0 +1,34 @@
+package com.sixjeon.storey.domain.owner.service;
+
+import com.sixjeon.storey.domain.auth.exception.DuplicateLoginIdException;
+import com.sixjeon.storey.domain.auth.web.dto.SignupReq;
+import com.sixjeon.storey.domain.owner.entity.Owner;
+import com.sixjeon.storey.domain.owner.repository.OwnerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OwnerServiceImpl implements OwnerService {
+
+    private final OwnerRepository ownerRepository;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    @Override
+    public Owner createOwner(SignupReq signupReq) {
+
+        if (ownerRepository.existsByLoginId(signupReq.getLoginId())) {
+            throw new DuplicateLoginIdException();
+        }
+
+        Owner owner = Owner.builder()
+                .loginId(signupReq.getLoginId())
+                .password(bCryptPasswordEncoder.encode(signupReq.getPassword()))
+                .phoneNumber(signupReq.getPhoneNumber())
+                .build();
+
+        return ownerRepository.save(owner);
+
+    }
+}

--- a/src/main/java/com/sixjeon/storey/domain/user/entity/ProviderType.java
+++ b/src/main/java/com/sixjeon/storey/domain/user/entity/ProviderType.java
@@ -1,0 +1,5 @@
+package com.sixjeon.storey.domain.user.entity;
+
+public enum ProviderType {
+    LOCAL, KAKAO
+}

--- a/src/main/java/com/sixjeon/storey/domain/user/entity/User.java
+++ b/src/main/java/com/sixjeon/storey/domain/user/entity/User.java
@@ -1,0 +1,35 @@
+package com.sixjeon.storey.domain.user.entity;
+
+import com.sixjeon.storey.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@AllArgsConstructor
+@Getter
+@Setter
+@NoArgsConstructor
+@Builder
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+    @Column(name = "login_id", nullable = false, unique = true)
+    private String loginId;
+    @Column(nullable = false)
+    private String password;
+    @Column(nullable = false, unique = true)
+    private String phoneNumber;
+    //Local(일반),KAKAO ..
+    @Enumerated(EnumType.STRING)
+    private ProviderType provider;
+    @Column(name = "provider_id")
+    private String providerId;
+
+
+
+
+
+}

--- a/src/main/java/com/sixjeon/storey/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/sixjeon/storey/domain/user/repository/UserRepository.java
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     Boolean existsByLoginId(String loginId);
+    Boolean existsByPhoneNumber(String phoneNumber);
 }

--- a/src/main/java/com/sixjeon/storey/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/sixjeon/storey/domain/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.sixjeon.storey.domain.user.repository;
+
+import com.sixjeon.storey.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    Boolean existsByLoginId(String loginId);
+}

--- a/src/main/java/com/sixjeon/storey/domain/user/service/UserService.java
+++ b/src/main/java/com/sixjeon/storey/domain/user/service/UserService.java
@@ -1,0 +1,8 @@
+package com.sixjeon.storey.domain.user.service;
+
+import com.sixjeon.storey.domain.auth.web.dto.SignupReq;
+import com.sixjeon.storey.domain.user.entity.User;
+
+public interface UserService {
+    User createUser(SignupReq signupReq);
+}

--- a/src/main/java/com/sixjeon/storey/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/sixjeon/storey/domain/user/service/UserServiceImpl.java
@@ -1,0 +1,35 @@
+package com.sixjeon.storey.domain.user.service;
+
+import com.sixjeon.storey.domain.user.entity.ProviderType;
+import com.sixjeon.storey.domain.auth.exception.DuplicateLoginIdException;
+import com.sixjeon.storey.domain.auth.web.dto.SignupReq;
+import com.sixjeon.storey.domain.user.entity.User;
+import com.sixjeon.storey.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+
+    @Override
+    public User createUser(SignupReq signupReq) {
+        if (userRepository.existsByLoginId(signupReq.getLoginId())) {
+            throw new DuplicateLoginIdException();
+        }
+
+        User user = User.builder()
+                .loginId(signupReq.getLoginId())
+                .password(bCryptPasswordEncoder.encode(signupReq.getPassword()))
+                .phoneNumber(signupReq.getPhoneNumber())
+                .provider(ProviderType.LOCAL)
+                .build();
+
+        return userRepository.save(user);
+    }
+}

--- a/src/main/java/com/sixjeon/storey/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/sixjeon/storey/domain/user/service/UserServiceImpl.java
@@ -19,9 +19,9 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public User createUser(SignupReq signupReq) {
-        if (userRepository.existsByLoginId(signupReq.getLoginId())) {
-            throw new DuplicateLoginIdException();
-        }
+//        if (userRepository.existsByLoginId(signupReq.getLoginId())) {
+//            throw new DuplicateLoginIdException();
+//        }
 
         User user = User.builder()
                 .loginId(signupReq.getLoginId())

--- a/src/main/java/com/sixjeon/storey/global/config/SecurityConfig.java
+++ b/src/main/java/com/sixjeon/storey/global/config/SecurityConfig.java
@@ -1,10 +1,12 @@
 package com.sixjeon.storey.global.config;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity
@@ -14,5 +16,19 @@ public class SecurityConfig {
     public BCryptPasswordEncoder bCryptPasswordEncoder() {
         return new BCryptPasswordEncoder();
 
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session ->  session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                        .authorizeHttpRequests(auth -> auth
+                                .requestMatchers("/api/auth/**").permitAll()
+                                .anyRequest().permitAll()
+                );
+
+
+        return http.build();
     }
 }

--- a/src/main/java/com/sixjeon/storey/global/config/SecurityConfig.java
+++ b/src/main/java/com/sixjeon/storey/global/config/SecurityConfig.java
@@ -1,0 +1,18 @@
+package com.sixjeon.storey.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=storey


### PR DESCRIPTION
## ✨ 작업 개요



<!-- 어떤 기능을 구현했는지 간단히 설명해주세요. -->

- role 값에 따라 사장님(OWNER)과 일반 사용자(USER)를 구분하여 가입시키는 통합 회원가입 API를 구현
## 📌 관련 이슈



- close #2 



## 📄 작업 내용

- 인증 서비스 로직 (AuthService)
  - signup 요청 시 role 값을 확인하여, 실제 계정 생성 로직을 OwnerService 또는 UserService에 위임하는 Dispatcher 역할 수행
  - Owner과 User 테이블 전체에서 loginId의 유일성 보장 -> 두 저장소를 모두 확인하는 로직 구현
  - 아이디 중복, 전화번호 중복 예외 커스텀 처리
- 도메인별 서비스 로직(OwnerService,UserService)
  - 비밀번호는 BCryptPasswordEncoder를 사용하여 해싱 처리
- 패키지 구조
  - auth는 인증/인가의 진입점, owner와 user는 각 도메인의 실제 데이터 처리 로직 담당 






