### PR TITLE
feat: 가게(사업자) 정보 등록 구현

### DIFF
--- a/src/main/java/com/sixjeon/storey/domain/owner/entity/Owner.java
+++ b/src/main/java/com/sixjeon/storey/domain/owner/entity/Owner.java
@@ -17,9 +17,6 @@ public class Owner extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "owner_id")
     private Long id;
-    // 사장님 이름 -> 회원가입 받을 때 입력받지 않으므로 nullable = true로 설정
-    @Column(name = "representative_name",nullable = true)
-    private String representativeName;
 
     @Column(name = "login_id", nullable = false, unique = true)
     private String loginId;

--- a/src/main/java/com/sixjeon/storey/domain/proprietor/web/dto/CheckProprietorReq.java
+++ b/src/main/java/com/sixjeon/storey/domain/proprietor/web/dto/CheckProprietorReq.java
@@ -1,11 +1,13 @@
 package com.sixjeon.storey.domain.proprietor.web.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class CheckProprietorReq {
     @NotBlank(message = "사업자번호가 비어있습니다.")
     private String businessNumber;

--- a/src/main/java/com/sixjeon/storey/domain/store/entity/Store.java
+++ b/src/main/java/com/sixjeon/storey/domain/store/entity/Store.java
@@ -1,0 +1,59 @@
+package com.sixjeon.storey.domain.store.entity;
+
+import com.sixjeon.storey.domain.owner.entity.Owner;
+import com.sixjeon.storey.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Store extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "store_name",nullable = false)
+    private String storeName;
+
+    @Column(name = "representative_name",nullable = false)
+    private String representativeName;
+
+    @Column(name = "business_number",nullable = false, unique = true)
+    private String businessNumber;
+
+    @Column(name = "business_type")
+    private String businessType;
+
+    @Column(name = "business_category")
+    private String businessCategory;
+
+    @Column(name = "address_main",nullable = false)
+    private String addressMain;
+
+    @Column(name = "address_detail",nullable = false)
+    private String addressDetail;
+
+    @Column(name = "postal_code",nullable = false)
+    private String postalCode;
+
+    private Double latitude;
+
+    private Double longitude;
+
+    @Column(name = "in_active",nullable = false)
+    @ColumnDefault("false")
+    private Boolean inActive;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "owner_id", nullable = false)
+    private Owner owner;
+
+
+
+
+
+}

--- a/src/main/java/com/sixjeon/storey/domain/store/exception/AlreadyRegisterStoreException.java
+++ b/src/main/java/com/sixjeon/storey/domain/store/exception/AlreadyRegisterStoreException.java
@@ -1,0 +1,9 @@
+package com.sixjeon.storey.domain.store.exception;
+
+import com.sixjeon.storey.global.exception.BaseException;
+
+public class AlreadyRegisterStoreException extends BaseException {
+    public AlreadyRegisterStoreException() {
+        super(StoreErrorCode.STORE_ALREADY_REGISTERED_409);
+    }
+}

--- a/src/main/java/com/sixjeon/storey/domain/store/exception/DuplicateBusinessNumberException.java
+++ b/src/main/java/com/sixjeon/storey/domain/store/exception/DuplicateBusinessNumberException.java
@@ -1,0 +1,9 @@
+package com.sixjeon.storey.domain.store.exception;
+
+import com.sixjeon.storey.global.exception.BaseException;
+
+public class DuplicateBusinessNumberException extends BaseException {
+    public DuplicateBusinessNumberException() {
+        super(StoreErrorCode.STORE_DUPLICATE_BUSINESS_NUMBER_409);
+    }
+}

--- a/src/main/java/com/sixjeon/storey/domain/store/exception/InvalidBusinessNumberException.java
+++ b/src/main/java/com/sixjeon/storey/domain/store/exception/InvalidBusinessNumberException.java
@@ -1,0 +1,9 @@
+package com.sixjeon.storey.domain.store.exception;
+
+import com.sixjeon.storey.global.exception.BaseException;
+
+public class InvalidBusinessNumberException extends BaseException {
+    public InvalidBusinessNumberException() {
+        super(StoreErrorCode.STORE_INVALID_BUSINESS_NUMBER_400);
+    }
+}

--- a/src/main/java/com/sixjeon/storey/domain/store/exception/StoreErrorCode.java
+++ b/src/main/java/com/sixjeon/storey/domain/store/exception/StoreErrorCode.java
@@ -8,7 +8,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum StoreErrorCode implements BaseResponseCode {
     STORE_INVALID_BUSINESS_NUMBER_400("STORE_INVALID_BUSINESS_NUMBER_400", 400, "사업자번호가 일치하지 않습니다."),
-    STORE_DUPLICATE_BUSINESS_NUMBER_409("STORE_DUPLICATE_BUSINESS_NUMBER_409", 409, "이미 등록된 사업자입니다.");
+    STORE_DUPLICATE_BUSINESS_NUMBER_409("STORE_DUPLICATE_BUSINESS_NUMBER_409", 409, "이미 등록된 사업자입니다."),
+    STORE_ALREADY_REGISTERED_409("STORE_ALREADY_REGISTERED_409", 409, "이미 등록된 가게가 존재합니다.");
 
     private final String code;
     private final int httpStatus;

--- a/src/main/java/com/sixjeon/storey/domain/store/exception/StoreErrorCode.java
+++ b/src/main/java/com/sixjeon/storey/domain/store/exception/StoreErrorCode.java
@@ -1,0 +1,16 @@
+package com.sixjeon.storey.domain.store.exception;
+
+import com.sixjeon.storey.global.response.code.BaseResponseCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum StoreErrorCode implements BaseResponseCode {
+    STORE_INVALID_BUSINESS_NUMBER_400("STORE_INVALID_BUSINESS_NUMBER_400", 400, "사업자번호가 일치하지 않습니다."),
+    STORE_DUPLICATE_BUSINESS_NUMBER_409("STORE_DUPLICATE_BUSINESS_NUMBER_409", 409, "이미 등록된 사업자입니다.");
+
+    private final String code;
+    private final int httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/sixjeon/storey/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/sixjeon/storey/domain/store/repository/StoreRepository.java
@@ -1,5 +1,6 @@
 package com.sixjeon.storey.domain.store.repository;
 
+import com.sixjeon.storey.domain.owner.entity.Owner;
 import com.sixjeon.storey.domain.store.entity.Store;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -7,4 +8,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface StoreRepository extends JpaRepository<Store, Long> {
     boolean existsByBusinessNumber(String businessNumber);
+    // 등록된 가게가 있는지 확인(사장님은 하나의 가게만 등록할 수 있기 때문)
+    boolean existsByOwner(Owner owner);
 }

--- a/src/main/java/com/sixjeon/storey/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/sixjeon/storey/domain/store/repository/StoreRepository.java
@@ -1,0 +1,10 @@
+package com.sixjeon.storey.domain.store.repository;
+
+import com.sixjeon.storey.domain.store.entity.Store;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StoreRepository extends JpaRepository<Store, Long> {
+    boolean existsByBusinessNumber(String businessNumber);
+}

--- a/src/main/java/com/sixjeon/storey/domain/store/service/StoreService.java
+++ b/src/main/java/com/sixjeon/storey/domain/store/service/StoreService.java
@@ -1,0 +1,8 @@
+package com.sixjeon.storey.domain.store.service;
+
+import com.sixjeon.storey.domain.store.web.dto.RegisterStoreReq;
+
+public interface StoreService {
+    // 가게 등록
+    void registerStore(RegisterStoreReq registerStoreReq, String ownerId);
+}

--- a/src/main/java/com/sixjeon/storey/domain/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/sixjeon/storey/domain/store/service/StoreServiceImpl.java
@@ -9,6 +9,7 @@ import com.sixjeon.storey.domain.proprietor.web.dto.CheckProprietorReq;
 import com.sixjeon.storey.domain.proprietor.web.dto.CheckProprietorRes;
 import com.sixjeon.storey.domain.store.entity.Store;
 import com.sixjeon.storey.domain.store.exception.AlreadyRegisterStoreException;
+import com.sixjeon.storey.domain.store.exception.DuplicateBusinessNumberException;
 import com.sixjeon.storey.domain.store.exception.InvalidBusinessNumberException;
 import com.sixjeon.storey.domain.store.repository.StoreRepository;
 import com.sixjeon.storey.domain.store.web.dto.RegisterStoreReq;
@@ -38,7 +39,7 @@ public class StoreServiceImpl implements StoreService {
 
         // 사업자 번호(businessNumber) 중복 체크
         if (storeRepository.existsByBusinessNumber(registerStoreReq.getBusinessNumber())) {
-            throw new DuplicatePhoneNumberException();
+            throw new DuplicateBusinessNumberException();
         }
 
         // 외부 API로 사업자 번호 유효성 검증

--- a/src/main/java/com/sixjeon/storey/domain/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/sixjeon/storey/domain/store/service/StoreServiceImpl.java
@@ -1,0 +1,63 @@
+package com.sixjeon.storey.domain.store.service;
+
+import com.sixjeon.storey.domain.auth.exception.DuplicatePhoneNumberException;
+import com.sixjeon.storey.domain.auth.exception.UserNotFoundException;
+import com.sixjeon.storey.domain.owner.entity.Owner;
+import com.sixjeon.storey.domain.owner.repository.OwnerRepository;
+import com.sixjeon.storey.domain.proprietor.service.ProprietorService;
+import com.sixjeon.storey.domain.proprietor.web.dto.CheckProprietorReq;
+import com.sixjeon.storey.domain.proprietor.web.dto.CheckProprietorRes;
+import com.sixjeon.storey.domain.store.entity.Store;
+import com.sixjeon.storey.domain.store.exception.InvalidBusinessNumberException;
+import com.sixjeon.storey.domain.store.repository.StoreRepository;
+import com.sixjeon.storey.domain.store.web.dto.RegisterStoreReq;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class StoreServiceImpl implements StoreService {
+
+    private final StoreRepository storeRepository;
+    private final OwnerRepository ownerRepository;
+    private final ProprietorService proprietorService;
+
+    @Override
+    @Transactional
+    public void registerStore(RegisterStoreReq registerStoreReq, String ownerLoginId) {
+        // 사장님 정보 확인
+        Owner owner = ownerRepository.findByLoginId(ownerLoginId)
+                .orElseThrow(UserNotFoundException::new);
+        // 사업자 번호(businessNumber) 중복 체크
+        if (storeRepository.existsByBusinessNumber(registerStoreReq.getBusinessNumber())) {
+            throw new DuplicatePhoneNumberException();
+        }
+
+        // 외부 API로 사업자 번호 유효성 검증
+        CheckProprietorReq checkReq = new CheckProprietorReq(registerStoreReq.getBusinessNumber());
+        CheckProprietorRes checkRes = proprietorService.checkProprietorNumber(checkReq);
+        if (!checkRes.pass()) {
+            throw new InvalidBusinessNumberException();
+        }
+
+
+        // 가게 등록
+        Store store = Store.builder()
+                .owner(owner)
+                .storeName(registerStoreReq.getStoreName())
+                .representativeName(registerStoreReq.getRepresentativeName())
+                .businessNumber(registerStoreReq.getBusinessNumber())
+                .businessType(registerStoreReq.getBusinessType())
+                .businessCategory(registerStoreReq.getBusinessCategory())
+                .addressMain(registerStoreReq.getAddressMain())
+                .addressDetail(registerStoreReq.getAddressDetail())
+                .postalCode(registerStoreReq.getPostalCode())
+                .inActive(false)
+                .build();
+        // DB에 저장
+        storeRepository.save(store);
+
+    }
+}
+

--- a/src/main/java/com/sixjeon/storey/domain/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/sixjeon/storey/domain/store/service/StoreServiceImpl.java
@@ -8,6 +8,7 @@ import com.sixjeon.storey.domain.proprietor.service.ProprietorService;
 import com.sixjeon.storey.domain.proprietor.web.dto.CheckProprietorReq;
 import com.sixjeon.storey.domain.proprietor.web.dto.CheckProprietorRes;
 import com.sixjeon.storey.domain.store.entity.Store;
+import com.sixjeon.storey.domain.store.exception.AlreadyRegisterStoreException;
 import com.sixjeon.storey.domain.store.exception.InvalidBusinessNumberException;
 import com.sixjeon.storey.domain.store.repository.StoreRepository;
 import com.sixjeon.storey.domain.store.web.dto.RegisterStoreReq;
@@ -29,6 +30,12 @@ public class StoreServiceImpl implements StoreService {
         // 사장님 정보 확인
         Owner owner = ownerRepository.findByLoginId(ownerLoginId)
                 .orElseThrow(UserNotFoundException::new);
+
+        // 이미 등록되어있는 가게가 있는지 확인
+        if (storeRepository.existsByOwner(owner)) {
+            throw new AlreadyRegisterStoreException();
+        }
+
         // 사업자 번호(businessNumber) 중복 체크
         if (storeRepository.existsByBusinessNumber(registerStoreReq.getBusinessNumber())) {
             throw new DuplicatePhoneNumberException();

--- a/src/main/java/com/sixjeon/storey/domain/store/web/controller/StoreController.java
+++ b/src/main/java/com/sixjeon/storey/domain/store/web/controller/StoreController.java
@@ -1,0 +1,32 @@
+package com.sixjeon.storey.domain.store.web.controller;
+
+import com.sixjeon.storey.domain.store.service.StoreService;
+import com.sixjeon.storey.domain.store.web.dto.RegisterStoreReq;
+import com.sixjeon.storey.global.response.SuccessResponse;
+import com.sixjeon.storey.global.security.details.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/stores")
+@RequiredArgsConstructor
+public class StoreController {
+
+    private final StoreService storeService;
+
+    @PostMapping
+    public ResponseEntity<SuccessResponse<?>> registerStore(
+            @Valid @RequestBody RegisterStoreReq registerStoreReq,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        storeService.registerStore(registerStoreReq, customUserDetails.getUsername());
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(SuccessResponse.created("가게 정보 성공정으로 등록되었습니다."));
+            }
+}

--- a/src/main/java/com/sixjeon/storey/domain/store/web/dto/RegisterStoreReq.java
+++ b/src/main/java/com/sixjeon/storey/domain/store/web/dto/RegisterStoreReq.java
@@ -1,0 +1,25 @@
+package com.sixjeon.storey.domain.store.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class RegisterStoreReq {
+    @NotBlank
+    private String storeName;
+    @NotBlank
+    private String representativeName;
+    @NotBlank
+    private String businessNumber;
+
+    private String businessType;
+    private String businessCategory;
+
+    @NotBlank
+    private String addressMain;
+
+    private String addressDetail;
+
+    @NotBlank
+    private String postalCode;
+}

--- a/src/main/java/com/sixjeon/storey/domain/user/entity/ProviderType.java
+++ b/src/main/java/com/sixjeon/storey/domain/user/entity/ProviderType.java
@@ -1,5 +1,0 @@
-package com.sixjeon.storey.domain.user.entity;
-
-public enum ProviderType {
-    LOCAL, KAKAO
-}

--- a/src/main/java/com/sixjeon/storey/domain/user/entity/User.java
+++ b/src/main/java/com/sixjeon/storey/domain/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.sixjeon.storey.domain.user.entity;
 
+import com.sixjeon.storey.domain.user.entity.enums.ProviderType;
 import com.sixjeon.storey.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/sixjeon/storey/domain/user/entity/enums/ProviderType.java
+++ b/src/main/java/com/sixjeon/storey/domain/user/entity/enums/ProviderType.java
@@ -1,0 +1,5 @@
+package com.sixjeon.storey.domain.user.entity.enums;
+
+public enum ProviderType {
+    LOCAL, KAKAO
+}

--- a/src/main/java/com/sixjeon/storey/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/sixjeon/storey/domain/user/service/UserServiceImpl.java
@@ -1,7 +1,6 @@
 package com.sixjeon.storey.domain.user.service;
 
-import com.sixjeon.storey.domain.user.entity.ProviderType;
-import com.sixjeon.storey.domain.auth.exception.DuplicateLoginIdException;
+import com.sixjeon.storey.domain.user.entity.enums.ProviderType;
 import com.sixjeon.storey.domain.auth.web.dto.SignupReq;
 import com.sixjeon.storey.domain.user.entity.User;
 import com.sixjeon.storey.domain.user.repository.UserRepository;

--- a/src/main/java/com/sixjeon/storey/global/config/SecurityConfig.java
+++ b/src/main/java/com/sixjeon/storey/global/config/SecurityConfig.java
@@ -32,6 +32,7 @@ public class SecurityConfig {
                         .authorizeHttpRequests(auth -> auth
                                 .requestMatchers("/auth/**").permitAll()
                                 .requestMatchers("/owner/**").hasRole("OWNER")
+                                .requestMatchers("/stores/**").hasRole("OWNER")
                                 .anyRequest().authenticated()
                 )
 


### PR DESCRIPTION
## ✨ 작업 개요



<!-- 어떤 기능을 구현했는지 간단히 설명해주세요. -->

- 사장님의 회원가입 절차의 일부로 자신의 가게 정보를 등록하는 API를 구현했습니다.
- 이 과정에서 기존에 있던 국세청 외부 API의 service로직을 사용하여 유효성을 검증하고 사장과 가게의 관계는 1대 1 규칙을 적용했습니다.

## 📌 관련 이슈



- close #8



## 📄 작업 내용

- 사장님만 가게 등록을 할 수 있게 권한 설정
- 가게 등록 API 추가



## 📷 UI 스크린샷 (해당 시)


- NOTION 정리


<!-- 전/후 비교 이미지 등 첨부 -->



## 💬 기타 사항

-



<!-- 리뷰어가 알면 좋을 내용이 있다면 적어주세요 -->

