### PR TITLE
feat: 첫번째 질문을 가게별 커스텀하여 반환하는 로직 구현

### DIFF
--- a/src/main/java/com/sixjeon/storey/domain/interview/entity/InterviewPair.java
+++ b/src/main/java/com/sixjeon/storey/domain/interview/entity/InterviewPair.java
@@ -1,0 +1,35 @@
+package com.sixjeon.storey.domain.interview.entity;
+
+import com.sixjeon.storey.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "interview_pair",
+        indexes = @Index(name = "idx_pair_session_step", columnList = "session_id, stepNo"))
+@Getter
+@Setter
+@NoArgsConstructor
+public class InterviewPair extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "pair_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "session_id", nullable = false)
+    private InterviewSession session;
+
+    @Column(nullable = false)
+    private Long stepNo;
+
+    @Lob
+    private String question;
+
+    @Lob
+    private String answer;
+
+}

--- a/src/main/java/com/sixjeon/storey/domain/interview/entity/InterviewSession.java
+++ b/src/main/java/com/sixjeon/storey/domain/interview/entity/InterviewSession.java
@@ -1,0 +1,27 @@
+package com.sixjeon.storey.domain.interview.entity;
+
+import com.sixjeon.storey.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "interview_session")
+@Getter
+@Setter
+@NoArgsConstructor
+public class InterviewSession extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "session_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private Long storeId;
+
+    // Large Object 뜻.
+    @Lob
+    private String narrativeSummary;
+}

--- a/src/main/java/com/sixjeon/storey/domain/interview/repository/InterviewPairRepository.java
+++ b/src/main/java/com/sixjeon/storey/domain/interview/repository/InterviewPairRepository.java
@@ -1,0 +1,11 @@
+package com.sixjeon.storey.domain.interview.repository;
+
+import com.sixjeon.storey.domain.interview.entity.InterviewPair;
+import com.sixjeon.storey.domain.interview.entity.InterviewSession;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface InterviewPairRepository extends JpaRepository<InterviewPair, Integer> {
+    List<InterviewPair> findBySessionOrderByStepNoAsc(InterviewSession session);
+}

--- a/src/main/java/com/sixjeon/storey/domain/interview/repository/InterviewSessionRepository.java
+++ b/src/main/java/com/sixjeon/storey/domain/interview/repository/InterviewSessionRepository.java
@@ -1,0 +1,10 @@
+package com.sixjeon.storey.domain.interview.repository;
+
+import com.sixjeon.storey.domain.interview.entity.InterviewSession;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface InterviewSessionRepository extends JpaRepository<InterviewSession, Integer> {
+    List<InterviewSession> findByStoreIdOrderByCreatedAtDesc(Long storeId);
+}

--- a/src/main/java/com/sixjeon/storey/domain/interview/web/controller/InterviewController.java
+++ b/src/main/java/com/sixjeon/storey/domain/interview/web/controller/InterviewController.java
@@ -1,6 +1,8 @@
 package com.sixjeon.storey.domain.interview.web.controller;
 
 import com.sixjeon.storey.domain.interview.service.InterviewService;
+import com.sixjeon.storey.domain.interview.web.dto.CharacterRes;
+import com.sixjeon.storey.domain.interview.web.dto.CreateQuestionReq;
 import com.sixjeon.storey.domain.interview.web.dto.InterviewReq;
 import com.sixjeon.storey.domain.interview.web.dto.InterviewRes;
 import com.sixjeon.storey.global.response.SuccessResponse;
@@ -18,6 +20,16 @@ public class InterviewController {
 
     private final InterviewService interviewService;
 
+    // 첫번째 질문 생성 (가게 업종, 분위기에 맞게)
+    @PostMapping("/interview/create")
+    public ResponseEntity<SuccessResponse<?>> startInterview(@RequestBody @Valid CreateQuestionReq createQuestionReq) {
+        InterviewRes interviewRes = interviewService.startInterview(createQuestionReq);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(SuccessResponse.ok(interviewRes));
+    }
+
     @PostMapping("/interview")
     public ResponseEntity<SuccessResponse<?>> interview(@RequestBody @Valid InterviewReq interviewReq) {
         InterviewRes interviewRes = interviewService.processInterview(interviewReq);
@@ -26,4 +38,15 @@ public class InterviewController {
                 .status(HttpStatus.OK)
                 .body(SuccessResponse.ok(interviewRes));
     }
+
+    // 캐릭터 생성 & 인터뷰 한줄 요약
+    /**@PostMapping("/character")
+    public ResponseEntity<SuccessResponse<?>> character(@RequestBody @Valid InterviewReq interviewReq) {
+        CharacterRes characterRes = interviewService.generateCharacter(interviewReq);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(SuccessResponse.ok(characterRes));
+    }
+    **/
 }

--- a/src/main/java/com/sixjeon/storey/domain/interview/web/dto/CharacterRes.java
+++ b/src/main/java/com/sixjeon/storey/domain/interview/web/dto/CharacterRes.java
@@ -1,0 +1,7 @@
+package com.sixjeon.storey.domain.interview.web.dto;
+
+public record CharacterRes(
+        String summary,
+        String imageBase64
+) {
+}

--- a/src/main/java/com/sixjeon/storey/domain/interview/web/dto/CreateQuestionReq.java
+++ b/src/main/java/com/sixjeon/storey/domain/interview/web/dto/CreateQuestionReq.java
@@ -1,0 +1,11 @@
+package com.sixjeon.storey.domain.interview.web.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CreateQuestionReq {
+    private String storeMood;
+    private String businessType;
+}


### PR DESCRIPTION
## ✨ 작업 개요



<!-- 어떤 기능을 구현했는지 간단히 설명해주세요. -->

- 가게별로 첫번째 질문을 커스텀하도록 구성했습니다.

## 📌 관련 이슈



- close #11 



## 📄 작업 내용

- 가게 분위기, 업종을 입력받아서 첫번째 질문을 가게마다 커스텀하도록 변경했습니다.



## 📷 UI 스크린샷 (해당 시)




<!-- 전/후 비교 이미지 등 첨부 -->



## 💬 기타 사항

-



<!-- 리뷰어가 알면 좋을 내용이 있다면 적어주세요 -->

