### PR TITLE
feat: 깜짝 이벤트 관리 로직

### DIFF
--- a/src/main/java/com/sixjeon/storey/domain/event/entity/Event.java
+++ b/src/main/java/com/sixjeon/storey/domain/event/entity/Event.java
@@ -27,7 +27,10 @@ public class Event extends BaseEntity {
     @JoinColumn(name = "store_id", nullable = false)
     private Store store;
 
-
+    // 이벤트 내용 수정을 위한 편의 메소드
+    public void updateContent(String content){
+        this.content = content;
+    }
 
 
 }

--- a/src/main/java/com/sixjeon/storey/domain/event/entity/Event.java
+++ b/src/main/java/com/sixjeon/storey/domain/event/entity/Event.java
@@ -1,0 +1,33 @@
+package com.sixjeon.storey.domain.event.entity;
+
+import com.sixjeon.storey.domain.store.entity.Store;
+import com.sixjeon.storey.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+public class Event extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="event_id")
+    private Long id;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id", nullable = false)
+    private Store store;
+
+
+
+
+}

--- a/src/main/java/com/sixjeon/storey/domain/event/exception/EventErrorCode.java
+++ b/src/main/java/com/sixjeon/storey/domain/event/exception/EventErrorCode.java
@@ -1,0 +1,16 @@
+package com.sixjeon.storey.domain.event.exception;
+
+import com.sixjeon.storey.global.response.code.BaseResponseCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum EventErrorCode implements BaseResponseCode {
+    EVENT_NOT_FOUND_404("EVENT_NOT_FOUND_404", 404, "이벤트가 찾을 수 없습니다.");
+
+
+    private final String code;
+    private final int httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/sixjeon/storey/domain/event/exception/EventNotFoundException.java
+++ b/src/main/java/com/sixjeon/storey/domain/event/exception/EventNotFoundException.java
@@ -1,0 +1,9 @@
+package com.sixjeon.storey.domain.event.exception;
+
+import com.sixjeon.storey.global.exception.BaseException;
+
+public class EventNotFoundException extends BaseException {
+    public EventNotFoundException() {
+        super(EventErrorCode.EVENT_NOT_FOUND_404);
+    }
+}

--- a/src/main/java/com/sixjeon/storey/domain/event/repository/EventRepository.java
+++ b/src/main/java/com/sixjeon/storey/domain/event/repository/EventRepository.java
@@ -1,0 +1,13 @@
+package com.sixjeon.storey.domain.event.repository;
+
+import com.sixjeon.storey.domain.event.entity.Event;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface EventRepository extends JpaRepository<Event, Long> {
+    // 가게 ID로 이벤트 조회
+    Optional<Event> findByStoreId(Long storeId);
+}

--- a/src/main/java/com/sixjeon/storey/domain/event/service/EventService.java
+++ b/src/main/java/com/sixjeon/storey/domain/event/service/EventService.java
@@ -1,8 +1,11 @@
 package com.sixjeon.storey.domain.event.service;
 
+import com.sixjeon.storey.domain.event.web.dto.SaveEventReq;
 import com.sixjeon.storey.domain.event.web.dto.SaveEventRes;
 
 public interface EventService {
     // 이벤트 조회
     SaveEventRes findStoreEvent(String OwnerLoginId);
+    // 이벤트 생성 및 수정
+    void createOrUpdateEvent(SaveEventReq saveEventReq, String ownerLoginId);
 }

--- a/src/main/java/com/sixjeon/storey/domain/event/service/EventService.java
+++ b/src/main/java/com/sixjeon/storey/domain/event/service/EventService.java
@@ -8,4 +8,7 @@ public interface EventService {
     SaveEventRes findStoreEvent(String OwnerLoginId);
     // 이벤트 생성 및 수정
     void createOrUpdateEvent(SaveEventReq saveEventReq, String ownerLoginId);
+    // 이벤트 삭제
+    void deleteEvent(String ownerLoginId);
+
 }

--- a/src/main/java/com/sixjeon/storey/domain/event/service/EventService.java
+++ b/src/main/java/com/sixjeon/storey/domain/event/service/EventService.java
@@ -1,0 +1,8 @@
+package com.sixjeon.storey.domain.event.service;
+
+import com.sixjeon.storey.domain.event.web.dto.SaveEventRes;
+
+public interface EventService {
+    // 이벤트 조회
+    SaveEventRes findStoreEvent(String OwnerLoginId);
+}

--- a/src/main/java/com/sixjeon/storey/domain/event/service/EventServiceImpl.java
+++ b/src/main/java/com/sixjeon/storey/domain/event/service/EventServiceImpl.java
@@ -1,0 +1,46 @@
+package com.sixjeon.storey.domain.event.service;
+
+import com.sixjeon.storey.domain.event.entity.Event;
+import com.sixjeon.storey.domain.event.exception.EventNotFoundException;
+import com.sixjeon.storey.domain.event.repository.EventRepository;
+import com.sixjeon.storey.domain.event.web.dto.SaveEventRes;
+import com.sixjeon.storey.domain.owner.entity.Owner;
+import com.sixjeon.storey.domain.owner.repository.OwnerRepository;
+import com.sixjeon.storey.domain.store.entity.Store;
+import com.sixjeon.storey.domain.store.exception.NotFoundStoreException;
+import com.sixjeon.storey.domain.store.repository.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import com.sixjeon.storey.domain.auth.exception.UserNotFoundException;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class EventServiceImpl implements EventService {
+
+    private final EventRepository eventRepository;
+    private final StoreRepository storeRepository;
+    private final OwnerRepository ownerRepository;
+
+    // 가게 이벤트 조회
+    @Override
+    @Transactional
+    public SaveEventRes findStoreEvent(String OwnerLoginId) {
+        Store store = findStoreByOwnerLoginId(OwnerLoginId);
+        Event event = eventRepository.findByStoreId(store.getId())
+                .orElseThrow(EventNotFoundException::new);
+
+        return SaveEventRes.builder()
+                .content(event.getContent())
+                .build();
+
+    }
+
+    private Store findStoreByOwnerLoginId(String ownerLoginId) {
+        Owner owner = ownerRepository.findByLoginId(ownerLoginId)
+                .orElseThrow(UserNotFoundException::new);
+        return storeRepository.findByOwner(owner)
+                .orElseThrow(NotFoundStoreException::new);
+
+    }
+}

--- a/src/main/java/com/sixjeon/storey/domain/event/service/EventServiceImpl.java
+++ b/src/main/java/com/sixjeon/storey/domain/event/service/EventServiceImpl.java
@@ -32,11 +32,12 @@ public class EventServiceImpl implements EventService {
                 .orElseThrow(EventNotFoundException::new);
 
         return SaveEventRes.builder()
+                .eventId(event.getId())
                 .content(event.getContent())
                 .build();
 
     }
-
+    // 가게 이벤트 생성 및 수정
     @Override
     @Transactional
     public void createOrUpdateEvent(SaveEventReq saveEventReq, String ownerLoginId) {
@@ -46,7 +47,7 @@ public class EventServiceImpl implements EventService {
         // 가게 ID로 이벤트 조회 -> 존재 유무에 따라 다른 작업 수행
         eventRepository.findByStoreId(store.getId())
                 .ifPresentOrElse(
-                      // 이벤트 존재 -> 내용 업데이트 (JPA 더티 채킹)
+                      // 이벤트 존재 -> 내용 업데이트 (JPA 더티 채킹)-> 새로운 필드가 만들어지는게 아님
                 existingEvent -> existingEvent.updateContent(saveEventReq.getContent()),
                             // 이벤트 없음 -> 새 이벤트 작성
                             () -> {
@@ -60,6 +61,19 @@ public class EventServiceImpl implements EventService {
                 );
 
 
+    }
+
+    @Override
+    @Transactional
+    public void deleteEvent(String ownerLoginId) {
+        // 로그인한 사장님의 가게 정보를 조회
+        Store store = findStoreByOwnerLoginId(ownerLoginId);
+        // 가게 ID로 삭제할 이벤트 조회
+        Event event = eventRepository.findByStoreId(store.getId())
+                .orElseThrow(EventNotFoundException::new);
+        // 이벤트 삭제
+        eventRepository.delete(event);
+        
     }
 
     private Store findStoreByOwnerLoginId(String ownerLoginId) {

--- a/src/main/java/com/sixjeon/storey/domain/event/web/controller/EventController.java
+++ b/src/main/java/com/sixjeon/storey/domain/event/web/controller/EventController.java
@@ -1,16 +1,16 @@
 package com.sixjeon.storey.domain.event.web.controller;
 
 import com.sixjeon.storey.domain.event.service.EventService;
+import com.sixjeon.storey.domain.event.web.dto.SaveEventReq;
 import com.sixjeon.storey.domain.event.web.dto.SaveEventRes;
 import com.sixjeon.storey.global.response.SuccessResponse;
 import com.sixjeon.storey.global.security.details.CustomUserDetails;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/owner/store/event")
@@ -27,6 +27,23 @@ public class EventController {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(SuccessResponse.ok(saveEventRes));
 
+    }
+
+    // 가게 이벤트 생성 및 수정
+    @PostMapping
+    public ResponseEntity<SuccessResponse<?>> createOrUpdateEvent(@Valid @RequestBody SaveEventReq saveEventReq,
+                                                                  @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        eventService.createOrUpdateEvent(saveEventReq, customUserDetails.getUsername());
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessResponse.ok("이벤트 정보 성공적으로 등록되었습니다."));
+    }
+
+    // 가게 이벤트 삭제
+    @DeleteMapping
+    public ResponseEntity<SuccessResponse<?>> deleteEvent(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        eventService.deleteEvent(customUserDetails.getUsername());
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessResponse.ok("이벤트 정보 성공적으로 삭제되었습니다."));
     }
 
 }

--- a/src/main/java/com/sixjeon/storey/domain/event/web/controller/EventController.java
+++ b/src/main/java/com/sixjeon/storey/domain/event/web/controller/EventController.java
@@ -1,0 +1,32 @@
+package com.sixjeon.storey.domain.event.web.controller;
+
+import com.sixjeon.storey.domain.event.service.EventService;
+import com.sixjeon.storey.domain.event.web.dto.SaveEventRes;
+import com.sixjeon.storey.global.response.SuccessResponse;
+import com.sixjeon.storey.global.security.details.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/owner/store/event")
+@RequiredArgsConstructor
+public class EventController {
+
+    private final EventService eventService;
+
+    // 가게 이벤트 조회
+    @GetMapping
+    public ResponseEntity<SuccessResponse<?>> findStoreEvent(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        SaveEventRes saveEventRes = eventService.findStoreEvent(customUserDetails.getUsername());
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessResponse.ok(saveEventRes));
+
+    }
+
+}

--- a/src/main/java/com/sixjeon/storey/domain/event/web/dto/SaveEventReq.java
+++ b/src/main/java/com/sixjeon/storey/domain/event/web/dto/SaveEventReq.java
@@ -1,0 +1,12 @@
+package com.sixjeon.storey.domain.event.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SaveEventReq {
+    @NotBlank(message = "이벤트 내용은 비워둘 수 없습니다.")
+    private String content;
+}

--- a/src/main/java/com/sixjeon/storey/domain/event/web/dto/SaveEventRes.java
+++ b/src/main/java/com/sixjeon/storey/domain/event/web/dto/SaveEventRes.java
@@ -1,0 +1,10 @@
+package com.sixjeon.storey.domain.event.web.dto;
+
+import lombok.Builder;
+
+@Builder
+public record SaveEventRes(
+        Long eventId,
+        String content
+) {
+}

--- a/src/main/java/com/sixjeon/storey/domain/owner/entity/Owner.java
+++ b/src/main/java/com/sixjeon/storey/domain/owner/entity/Owner.java
@@ -1,5 +1,6 @@
 package com.sixjeon.storey.domain.owner.entity;
 
+import com.sixjeon.storey.domain.store.entity.Store;
 import com.sixjeon.storey.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
@@ -33,6 +34,9 @@ public class Owner extends BaseEntity {
         this.password = password;
         this.phoneNumber = phoneNumber;
     }
+
+    @OneToOne(mappedBy = "owner", fetch = FetchType.LAZY)
+    private Store store;
 
 
 

--- a/src/main/java/com/sixjeon/storey/domain/store/exception/NotFoundStoreException.java
+++ b/src/main/java/com/sixjeon/storey/domain/store/exception/NotFoundStoreException.java
@@ -1,0 +1,9 @@
+package com.sixjeon.storey.domain.store.exception;
+
+import com.sixjeon.storey.global.exception.BaseException;
+
+public class NotFoundStoreException extends BaseException {
+  public NotFoundStoreException() {
+    super(StoreErrorCode.STORE_NOT_FOUND_404);
+  }
+}

--- a/src/main/java/com/sixjeon/storey/domain/store/exception/StoreErrorCode.java
+++ b/src/main/java/com/sixjeon/storey/domain/store/exception/StoreErrorCode.java
@@ -9,7 +9,8 @@ import lombok.Getter;
 public enum StoreErrorCode implements BaseResponseCode {
     STORE_INVALID_BUSINESS_NUMBER_400("STORE_INVALID_BUSINESS_NUMBER_400", 400, "사업자번호가 일치하지 않습니다."),
     STORE_DUPLICATE_BUSINESS_NUMBER_409("STORE_DUPLICATE_BUSINESS_NUMBER_409", 409, "이미 등록된 사업자입니다."),
-    STORE_ALREADY_REGISTERED_409("STORE_ALREADY_REGISTERED_409", 409, "이미 등록된 가게가 존재합니다.");
+    STORE_ALREADY_REGISTERED_409("STORE_ALREADY_REGISTERED_409", 409, "이미 등록된 가게가 존재합니다."),
+    STORE_NOT_FOUND_404("STORE_NOT_FOUND_404", 404, "가게가 찾을 수 없습니다.");
 
     private final String code;
     private final int httpStatus;

--- a/src/main/java/com/sixjeon/storey/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/sixjeon/storey/domain/store/repository/StoreRepository.java
@@ -5,9 +5,13 @@ import com.sixjeon.storey.domain.store.entity.Store;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface StoreRepository extends JpaRepository<Store, Long> {
     boolean existsByBusinessNumber(String businessNumber);
     // 등록된 가게가 있는지 확인(사장님은 하나의 가게만 등록할 수 있기 때문)
     boolean existsByOwner(Owner owner);
+    // Owner로 가게 조회
+    Optional<Store> findByOwner(Owner owner);
 }

--- a/src/main/java/com/sixjeon/storey/domain/store/web/controller/StoreController.java
+++ b/src/main/java/com/sixjeon/storey/domain/store/web/controller/StoreController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
-@RequestMapping("/stores")
+@RequestMapping("/owner/store")
 @RequiredArgsConstructor
 public class StoreController {
 


### PR DESCRIPTION
## ✨ 작업 개요



<!-- 어떤 기능을 구현했는지 간단히 설명해주세요. -->

- 사장님이 자신의 가게에 대한 깜짝 이벤트를 등록, 조회, 수정, 삭제할 수 있는 CTUD API 구현

## 📌 관련 이슈



- close #16 



## 📄 작업 내용

- Event 도메인 신규 생성
   - 현재 store와 양방향 매핑되어있는데 추후 수정 가능성 있음
- 조회, 생성 및 수정, 삭제로 3개의 함수로 구현함
  - 조회는 플레이스홀더용으로서 프론트엔드에서 페이지 진입 시 호출하여, 기존 이벤트가 있으면 404 반환
  - 생성 및 수정은 이벤트가 없으면 새로 생성(INSERT)하고 있으면 기존 내용을 수정


## 💬 기타 사항

- 모든 API는 eventId가 아닌, OwnerLoginId를 기준으로 동작 -> 사장님을 찾고 가게를 찾고 이벤트를 찾는다.
- 다른 사장님의 이벤트에 접근할 수 있는 가능성을 차단 


<!-- 리뷰어가 알면 좋을 내용이 있다면 적어주세요 -->

