### PR TITLE
feat: 1달 무료 구독 로직 생성

### DIFF
--- a/src/main/java/com/sixjeon/storey/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/sixjeon/storey/domain/auth/service/AuthServiceImpl.java
@@ -66,7 +66,7 @@ public class AuthServiceImpl implements AuthService {
                         .planName("MASCOT_BRANDING_PASS")
                         .startDate(null)
                         .endDate(null)
-                        .status(SubscriptionStatus.TRAIL_AVAILABLE)
+                        .status(SubscriptionStatus.TRIAL_AVAILABLE)
                         .build();
 
                 // Subscriptio을 DB에 저장

--- a/src/main/java/com/sixjeon/storey/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/sixjeon/storey/domain/auth/service/AuthServiceImpl.java
@@ -60,13 +60,13 @@ public class AuthServiceImpl implements AuthService {
                 // owner 저장
                 ownerRepository.save(owner);
 
-                // 추가(1개월 무료 체험 구독)
+                // 1달 무료 체험을 할 수 있는 자격이 주어짐
                 Subscription freeTrial = Subscription.builder()
                         .owner(owner) // owner 매핑
                         .planName("MASCOT_BRANDING_PASS")
-                        .startDate(LocalDateTime.now())
-                        .endDate(LocalDateTime.now().plusMonths(1)) // 만료일은 시작일로부터 1개월 뒤
-                        .status(SubscriptionStatus.ACTIVE) // 무료 체험 -> 활성
+                        .startDate(null)
+                        .endDate(null)
+                        .status(SubscriptionStatus.TRAIL_AVAILABLE)
                         .build();
 
                 // Subscriptio을 DB에 저장

--- a/src/main/java/com/sixjeon/storey/domain/store/web/controller/StoreController.java
+++ b/src/main/java/com/sixjeon/storey/domain/store/web/controller/StoreController.java
@@ -41,7 +41,7 @@ public class StoreController {
     }
     
     // 특정 가게 상세 정보 조회
-    @GetMapping("/store/{storeId}")
+    @GetMapping("/stores/{storeId}")
     public ResponseEntity<SuccessResponse<?>> getStoreDetail(@PathVariable Long storeId) {
         StoreDetailRes storeDetailRes = storeService.findStoreDetail(storeId);
         return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/com/sixjeon/storey/domain/subscription/entity/Subscription.java
+++ b/src/main/java/com/sixjeon/storey/domain/subscription/entity/Subscription.java
@@ -49,4 +49,10 @@ public class Subscription extends BaseEntity {
         this.endDate = this.endDate.plusMonths(1);
         this.status = SubscriptionStatus.ACTIVE;
     }
+    // 무료 체험 시작 메소드
+    public void startTrial() {
+        this.status= SubscriptionStatus.ACTIVE;
+        this.startDate = LocalDateTime.now();
+        this.endDate = LocalDateTime.now().plusMonths(1);
+    }
 }

--- a/src/main/java/com/sixjeon/storey/domain/subscription/entity/Subscription.java
+++ b/src/main/java/com/sixjeon/storey/domain/subscription/entity/Subscription.java
@@ -26,10 +26,10 @@ public class Subscription extends BaseEntity {
     @Column(nullable = false)
     private String planName;
     // 구독 시작일
-    @Column(name = "start_date", nullable = false)
+    @Column(name = "start_date", nullable = true)
     private LocalDateTime startDate;
     // 구독 만료일
-    @Column(name = "end_date", nullable = false)
+    @Column(name = "end_date", nullable = true)
     private LocalDateTime endDate;
     // 구독 상태
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/sixjeon/storey/domain/subscription/entity/enums/SubscriptionStatus.java
+++ b/src/main/java/com/sixjeon/storey/domain/subscription/entity/enums/SubscriptionStatus.java
@@ -4,5 +4,6 @@ public enum SubscriptionStatus {
     ACTIVE, // 활성 상태
     CANCELED_REQUESTED, // 해지 신청(유효일까지 지속)
     CANCELED, // 해지 취소
-    EXPIRED // 구독 기간 만료된 상태
+    EXPIRED, // 구독 기간 만료된 상태
+    TRAIL_AVAILABLE // 무료 체험 가능 상태
 }

--- a/src/main/java/com/sixjeon/storey/domain/subscription/entity/enums/SubscriptionStatus.java
+++ b/src/main/java/com/sixjeon/storey/domain/subscription/entity/enums/SubscriptionStatus.java
@@ -5,5 +5,5 @@ public enum SubscriptionStatus {
     CANCELED_REQUESTED, // 해지 신청(유효일까지 지속)
     CANCELED, // 해지 취소
     EXPIRED, // 구독 기간 만료된 상태
-    TRAIL_AVAILABLE // 무료 체험 가능 상태
+    TRIAL_AVAILABLE // 무료 체험 가능 상태
 }

--- a/src/main/java/com/sixjeon/storey/domain/subscription/exception/InvalidSubscriptionStatusException.java
+++ b/src/main/java/com/sixjeon/storey/domain/subscription/exception/InvalidSubscriptionStatusException.java
@@ -1,0 +1,9 @@
+package com.sixjeon.storey.domain.subscription.exception;
+
+import com.sixjeon.storey.global.exception.BaseException;
+
+public class InvalidSubscriptionStatusException extends BaseException {
+    public InvalidSubscriptionStatusException() {
+        super(SubscriptionErrorCode.SUBSCRIPTION_INVALID_STATUS_409);
+    }
+}

--- a/src/main/java/com/sixjeon/storey/domain/subscription/exception/SubscriptionErrorCode.java
+++ b/src/main/java/com/sixjeon/storey/domain/subscription/exception/SubscriptionErrorCode.java
@@ -7,7 +7,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum SubscriptionErrorCode implements BaseResponseCode {
-    SUBSCRIPTION_NOT_FOUND_404("SUBSCRIPTION_NOT_FOUND_404", 404, "구독 정보를 찾을 수 없습니다.");
+    SUBSCRIPTION_NOT_FOUND_404("SUBSCRIPTION_NOT_FOUND_404", 404, "구독 정보를 찾을 수 없습니다."),
+    SUBSCRIPTION_INVALID_STATUS_409("SUBSCRIPTION_INVALID_STATUS_409", 409, "무료 체험을 시작할 수 없는 상태입니다.");
 
 
     private final String code;

--- a/src/main/java/com/sixjeon/storey/domain/subscription/service/SubscriptionService.java
+++ b/src/main/java/com/sixjeon/storey/domain/subscription/service/SubscriptionService.java
@@ -18,4 +18,7 @@ public interface SubscriptionService {
     // 자동 구독 갱신
     void renewSubscription();
 
+    // 무료 체험 시작 로직
+    void startFreeTrial(String ownerLoginId);
+
 }

--- a/src/main/java/com/sixjeon/storey/domain/subscription/service/SubscriptionServiceImpl.java
+++ b/src/main/java/com/sixjeon/storey/domain/subscription/service/SubscriptionServiceImpl.java
@@ -5,6 +5,7 @@ import com.sixjeon.storey.domain.owner.entity.Owner;
 import com.sixjeon.storey.domain.owner.repository.OwnerRepository;
 import com.sixjeon.storey.domain.subscription.entity.Subscription;
 import com.sixjeon.storey.domain.subscription.entity.enums.SubscriptionStatus;
+import com.sixjeon.storey.domain.subscription.exception.InvalidSubscriptionStatusException;
 import com.sixjeon.storey.domain.subscription.exception.SubscriptionNotFoundException;
 import com.sixjeon.storey.domain.subscription.repository.SubscriptionRepository;
 import com.sixjeon.storey.domain.subscription.web.dto.CardRegistrationReq;
@@ -33,7 +34,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
     private final String PLAN_NAME = "마스코트 브랜딩 패스";
     private final Long PLAN_PRICE = 20900L;
 
-    // [무료 체험 중]인 사장님이 결제 카드를 미리 등록하는 로직
+    // 카드 등록 로직
     @Override
     @Transactional
     public void registerCard(CardRegistrationReq cardRegistrationReq, String ownerLoginId) {
@@ -152,6 +153,18 @@ public class SubscriptionServiceImpl implements SubscriptionService {
 
     }
 
+    @Override
+    @Transactional
+    public void startFreeTrial(String ownerLoginId) {
+        Owner owner = ownerRepository.findByLoginId(ownerLoginId)
+                .orElseThrow(UserNotFoundException::new);
 
+        Subscription subscription = subscriptionRepository.findByOwnerId(owner.getId())
+                .orElseThrow(SubscriptionNotFoundException::new);
 
+        if (!SubscriptionStatus.TRIAL_AVAILABLE.equals(subscription.getStatus())) {
+                throw new InvalidSubscriptionStatusException();
+        }
+        subscription.startTrial();
+    }
 }

--- a/src/main/java/com/sixjeon/storey/domain/subscription/web/controller/SubscriptionController.java
+++ b/src/main/java/com/sixjeon/storey/domain/subscription/web/controller/SubscriptionController.java
@@ -20,7 +20,7 @@ public class SubscriptionController {
 
     private final SubscriptionService subscriptionService;
 
-    // 무료 체험 중 결제 카드 등록 API
+    //  카드 등록 API
     @PostMapping("/card")
     public ResponseEntity<SuccessResponse<?>> registerCard(@RequestBody @Valid CardRegistrationReq cardRegistrationReq,
                                                            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
@@ -53,6 +53,14 @@ public class SubscriptionController {
         subscriptionService.cancelSubscription(customUserDetails.getUsername());
         return ResponseEntity.status(HttpStatus.OK)
                 .body(SuccessResponse.ok("구독 취소가 성공적으로 완료되었습니다."));
+    }
+
+    // 무료 체험 시작 API
+    @PostMapping("/trial")
+    public ResponseEntity<SuccessResponse<?>> startTrial(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        subscriptionService.startFreeTrial(customUserDetails.getUsername());
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessResponse.ok("무료 체험 시작이 성공적으로 완료되었습니다."));
     }
 
 }

--- a/src/main/java/com/sixjeon/storey/global/config/SecurityConfig.java
+++ b/src/main/java/com/sixjeon/storey/global/config/SecurityConfig.java
@@ -28,12 +28,15 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
+                .cors(cors -> cors.disable())
                 .sessionManagement(session ->  session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                         .authorizeHttpRequests(auth -> auth
-                                .requestMatchers("/auth/**").permitAll()
+                                .requestMatchers("/auth/signup", "/auth/owner/login", "/auth/user/login", "/auth/refresh").permitAll()
+                                .requestMatchers("/user/logout").authenticated()
                                 .requestMatchers("/owner/**").hasRole("OWNER")
                                 .requestMatchers("/store/**").hasRole("OWNER")
-                                .anyRequest().permitAll()
+                                .requestMatchers("/stores/**").permitAll()
+                                .anyRequest().authenticated()
                 )
 
                 .addFilterBefore(jwtTokenFilter, UsernamePasswordAuthenticationFilter.class);


### PR DESCRIPTION
## ✨ 작업 개요



<!-- 어떤 기능을 구현했는지 간단히 설명해주세요. -->

- 기존의 회원가입 즉시 구독이 활성화되던 정책을 변경하여, 사용자에게 무료 체험 '기회'를 부여하고 원할 때 직접 체험을 시작할 수 있도록 구독 플로우를 전면 개편했습니다. 이를 위해 새로운 API를 추가하고 관련 로직을 수정했습니다.

## 📌 관련 이슈



- close #28 


## 📄 작업 내용

- 무료 체험 가능한 상태를 나타내는 TRIAL_AVAILABLE enum 상수 추가
- 회원 가입 로직 변경
  - 회원가입 시, 구독 정보가 TRIAL_AVAILABLE 상태로 생성
  - startDate, endDate는 NULL
- 무료 체험 시작 API 추가
- 로그아웃 권한 설정


## 💬 기타 사항

-



<!-- 리뷰어가 알면 좋을 내용이 있다면 적어주세요 -->

