### PR TITLE
feat: 구독 여부, 해금 여부 에따른 지도 표현 로직 작성

### DIFF
--- a/src/main/java/com/sixjeon/storey/domain/character/repository/CharacterRepository.java
+++ b/src/main/java/com/sixjeon/storey/domain/character/repository/CharacterRepository.java
@@ -4,6 +4,12 @@ import com.sixjeon.storey.domain.character.entity.Character;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface CharacterRepository extends JpaRepository<Character, Long> {
+    // storeId로 캐릭터 찾기
+    Optional<Character> findByStoreId(Long storeId);
+    // 가게에 캐릭터가 있는지 확인 메소드
+    boolean existsByStoreId(Long storeId);
 }

--- a/src/main/java/com/sixjeon/storey/domain/store/entity/Store.java
+++ b/src/main/java/com/sixjeon/storey/domain/store/entity/Store.java
@@ -10,6 +10,7 @@ import org.hibernate.annotations.ColumnDefault;
 @Entity
 @Getter
 @Builder
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class Store extends BaseEntity {
@@ -45,13 +46,18 @@ public class Store extends BaseEntity {
 
     private Double longitude;
 
+    @Column(name = "qr_code", unique = true)
+    private String qrCode;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "owner_id", nullable = false)
     private Owner owner;
 
-//    @OneToOne(mappedBy = "store", fetch = FetchType.LAZY)
-//    private Event event;
+    // QR 코드 생성 메소드
+    public void generateQrCode() {
+        this.qrCode = "STORE_" + this.id + "_" + java.util.UUID.randomUUID();
+    }
+
 
 
 

--- a/src/main/java/com/sixjeon/storey/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/sixjeon/storey/domain/store/repository/StoreRepository.java
@@ -17,13 +17,10 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
     boolean existsByOwner(Owner owner);
     // Owner로 가게 조회
     Optional<Store> findByOwner(Owner owner);
-    /*
-    * 지도에 표시할 모든 가게 정보를 조회하는 쿼리
-    * Store와 Event를 Left Join함
-    * */
-    @Query("SELECT new com.sixjeon.storey.domain.store.web.dto.MapStoreRes(s.id, s.storeName, s.addressMain, s.latitude, s.longitude, e.content) " +
-            "FROM Store s LEFT JOIN Event e ON s.id = e.store.id")
-    List<MapStoreRes> findAllWithEvent();
+    // QR 코드 문자열로 가게를 찾아서 반환
+    Optional<Store> findByQrCode(String qrCode);
+    // QR 코드가 DB에 존재하는지 true/false -> 중복 체크용
+    boolean existsByQrCode(String qrCode);
 
 
 

--- a/src/main/java/com/sixjeon/storey/domain/store/service/StoreService.java
+++ b/src/main/java/com/sixjeon/storey/domain/store/service/StoreService.java
@@ -9,8 +9,10 @@ import java.util.List;
 public interface StoreService {
     // 가게 등록
     void registerStore(RegisterStoreReq registerStoreReq, String ownerId);
-    // 지도에서 모든 가게 조회
-    List<MapStoreRes> findAllStoresForMap();
-    // 지도에서 가게 상세 조회
-    StoreDetailRes findStoreDetail(Long storeId);
+    /* 사용자별 가게 조회
+    * 1. 구독한 가게만 표시
+    * 2. 해금 상태에 따라 자물쇠 캐릭터 구분
+    * */
+    List<MapStoreRes> findAllStoresForUserMap(String userLoginId);
+
 }

--- a/src/main/java/com/sixjeon/storey/domain/store/web/controller/StoreController.java
+++ b/src/main/java/com/sixjeon/storey/domain/store/web/controller/StoreController.java
@@ -1,5 +1,7 @@
 package com.sixjeon.storey.domain.store.web.controller;
 
+import com.sixjeon.storey.domain.store.entity.Store;
+import com.sixjeon.storey.domain.store.repository.StoreRepository;
 import com.sixjeon.storey.domain.store.service.StoreService;
 import com.sixjeon.storey.domain.store.web.dto.MapStoreRes;
 import com.sixjeon.storey.domain.store.web.dto.RegisterStoreReq;
@@ -17,11 +19,12 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping
+@RequestMapping("/user")
 @RequiredArgsConstructor
 public class StoreController {
 
     private final StoreService storeService;
+    private final StoreRepository storeRepository;
 
     @PostMapping("/owner/store")
     public ResponseEntity<SuccessResponse<?>> registerStore(
@@ -34,19 +37,13 @@ public class StoreController {
 
     // 지도에서 모든 가게 조회
     @GetMapping("/stores/map")
-    public ResponseEntity<SuccessResponse<?>> getStoresForMap() {
-        List<MapStoreRes> mapStoreRes = storeService.findAllStoresForMap();
+    public ResponseEntity<SuccessResponse<?>> getStoresForMap(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        List<MapStoreRes> mapStoreRes = storeService.findAllStoresForUserMap(customUserDetails.getUsername());
+
         return ResponseEntity.status(HttpStatus.OK)
                 .body(SuccessResponse.ok(mapStoreRes));
     }
-    
-    // 특정 가게 상세 정보 조회
-    @GetMapping("/stores/{storeId}")
-    public ResponseEntity<SuccessResponse<?>> getStoreDetail(@PathVariable Long storeId) {
-        StoreDetailRes storeDetailRes = storeService.findStoreDetail(storeId);
-        return ResponseEntity.status(HttpStatus.OK)
-                .body(SuccessResponse.ok(storeDetailRes));
-    }
+
 
 
 

--- a/src/main/java/com/sixjeon/storey/domain/store/web/dto/MapStoreRes.java
+++ b/src/main/java/com/sixjeon/storey/domain/store/web/dto/MapStoreRes.java
@@ -1,15 +1,18 @@
 package com.sixjeon.storey.domain.store.web.dto;
 
+import com.sixjeon.storey.domain.subscription.entity.enums.SubscriptionStatus;
 import lombok.Builder;
 
 @Builder
 public record MapStoreRes(
-        // 캐릭터 필드 추가 예정
         Long storeId,
         String storeName,
         String addressMain,
         Double latitude,
         Double longitude,
-        String eventContent
+        String eventContent,
+        boolean isUnlocked,
+        String characterImageUrl,
+        SubscriptionStatus subscriptionStatus
 ) {
 }

--- a/src/main/java/com/sixjeon/storey/domain/user/entity/User.java
+++ b/src/main/java/com/sixjeon/storey/domain/user/entity/User.java
@@ -1,8 +1,13 @@
 package com.sixjeon.storey.domain.user.entity;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sixjeon.storey.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 @AllArgsConstructor
@@ -25,6 +30,44 @@ public class User extends BaseEntity {
     
     @Column(name = "refresh_token" , length = 500)
     private String refreshToken;
+    // 수집한 스토어 Id
+    // JSON 배열을 문자열로 저장할거임
+    @Column(name = "unlocked_store_ids", columnDefinition = "TEXT")
+    private String unlockedStoreIds;
+
+    // JSON -> JAVA 변환
+    public Set<Long> getUnlockedStoreIdSet() {
+        // null 및 빈 문자열 체크
+        if (unlockedStoreIds == null || unlockedStoreIds.trim().isEmpty()) {
+            return new HashSet<>();
+        }
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            TypeReference<Set<Long>> typeRef = new TypeReference<Set<Long>>() {};
+            return mapper.readValue(unlockedStoreIds, typeRef);
+        } catch (Exception e) {
+            return new HashSet<>();
+        }
+    }
+
+
+    // QR 스캔 시 해금 목룍에 추가
+    public void addUnlockedStoreId(Long storeId) {
+        Set<Long> currentIds = getUnlockedStoreIdSet();
+        currentIds.add(storeId);
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            this.unlockedStoreIds = mapper.writeValueAsString(currentIds);
+        } catch (Exception e) {
+
+        }
+    }
+
+    // 지도에서 lock 과 캐릭터 판단
+    public boolean isStoreUnlocked(Long storeId) {
+        return getUnlockedStoreIdSet().contains(storeId);
+
+    }
 
     // Refresh Token 업데이트 메서드
     public void updateRefreshToken(String refreshToken) {

--- a/src/main/java/com/sixjeon/storey/domain/user/web/dto/CollectedCharacterRes.java
+++ b/src/main/java/com/sixjeon/storey/domain/user/web/dto/CollectedCharacterRes.java
@@ -1,0 +1,8 @@
+package com.sixjeon.storey.domain.user.web.dto;
+
+public record CollectedCharacter(
+        Long storeId,
+        String storeName,
+        String characterImageUrl
+) {
+}

--- a/src/main/java/com/sixjeon/storey/domain/user/web/dto/CollectedCharacterRes.java
+++ b/src/main/java/com/sixjeon/storey/domain/user/web/dto/CollectedCharacterRes.java
@@ -1,6 +1,6 @@
 package com.sixjeon.storey.domain.user.web.dto;
 
-public record CollectedCharacter(
+public record CollectedCharacterRes(
         Long storeId,
         String storeName,
         String characterImageUrl

--- a/src/main/java/com/sixjeon/storey/domain/user/web/dto/CollectionRes.java
+++ b/src/main/java/com/sixjeon/storey/domain/user/web/dto/CollectionRes.java
@@ -1,4 +1,9 @@
 package com.sixjeon.storey.domain.user.web.dto;
 
-public record CollectionRes() {
+import java.util.List;
+
+public record CollectionRes(
+        List<CollectedCharacterRes> collectedCharacters,
+        int totalCount
+) {
 }

--- a/src/main/java/com/sixjeon/storey/domain/user/web/dto/CollectionRes.java
+++ b/src/main/java/com/sixjeon/storey/domain/user/web/dto/CollectionRes.java
@@ -1,0 +1,4 @@
+package com.sixjeon.storey.domain.user.web.dto;
+
+public record CollectionRes() {
+}

--- a/src/main/java/com/sixjeon/storey/domain/user/web/dto/QrScanReq.java
+++ b/src/main/java/com/sixjeon/storey/domain/user/web/dto/QrScanReq.java
@@ -1,0 +1,12 @@
+package com.sixjeon.storey.domain.user.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class QrScanReq {
+    @NotBlank
+    private String qrCode;
+}


### PR DESCRIPTION
## ✨ 작업 개요



<!-- 어떤 기능을 구현했는지 간단히 설명해주세요. -->

- 사용자의 지도에 표시되는 가게와 표시되지 않는 가게, 해금 상태에 따른 가게 표현 상태 구분

## 📌 관련 이슈



- close #31 



## 📄 작업 내용

- 반환 값에 enum으로 Status 반환으로 구독 상태에 따른 노출 상태 구분
- 가게 상세 조회
- user만 권한을 가짐


## 💬 기타 사항

-



<!-- 리뷰어가 알면 좋을 내용이 있다면 적어주세요 -->

