### PR TITLE
feat: 캐릭터 API 권한 구분 및 내 캐릭터 조회 기능 추가

### DIFF
--- a/src/main/java/com/sixjeon/storey/domain/character/service/CharacterService.java
+++ b/src/main/java/com/sixjeon/storey/domain/character/service/CharacterService.java
@@ -1,9 +1,6 @@
 package com.sixjeon.storey.domain.character.service;
 
-import com.sixjeon.storey.domain.character.web.dto.CharacterDetailRes;
-import com.sixjeon.storey.domain.character.web.dto.CharacterRes;
-import com.sixjeon.storey.domain.character.web.dto.UpdateCharacterReq;
-import com.sixjeon.storey.domain.character.web.dto.UpdateCharacterRes;
+import com.sixjeon.storey.domain.character.web.dto.*;
 import com.sixjeon.storey.domain.interview.web.dto.InterviewReq;
 
 public interface CharacterService {
@@ -14,5 +11,7 @@ public interface CharacterService {
     // 캐릭터 상세 조회
     CharacterDetailRes getCharacterDetail(Long characterId);
     // 캐릭터 정보 수정
-    UpdateCharacterRes updateCharacter(Long characterId, UpdateCharacterReq characterUpdateReq, String ownerLoginId);
+    UpdateCharacterRes updateCharacter(UpdateCharacterReq characterUpdateReq, String ownerLoginId);
+    // 사장님용 내 캐릭터 조회
+    MyCharacterRes getMyCharacter(String ownerLoginId);
 }

--- a/src/main/java/com/sixjeon/storey/domain/character/web/controller/CharacterController.java
+++ b/src/main/java/com/sixjeon/storey/domain/character/web/controller/CharacterController.java
@@ -1,10 +1,7 @@
 package com.sixjeon.storey.domain.character.web.controller;
 
 import com.sixjeon.storey.domain.character.service.CharacterService;
-import com.sixjeon.storey.domain.character.web.dto.CharacterDetailRes;
-import com.sixjeon.storey.domain.character.web.dto.CharacterRes;
-import com.sixjeon.storey.domain.character.web.dto.UpdateCharacterReq;
-import com.sixjeon.storey.domain.character.web.dto.UpdateCharacterRes;
+import com.sixjeon.storey.domain.character.web.dto.*;
 import com.sixjeon.storey.domain.interview.web.dto.InterviewReq;
 import com.sixjeon.storey.global.response.SuccessResponse;
 import com.sixjeon.storey.global.security.details.CustomUserDetails;
@@ -42,7 +39,7 @@ public class CharacterController {
                 .body(SuccessResponse.ok(characterRes));
     }
 
-    @GetMapping("/characters/{characterId}")
+    @GetMapping("/user/characters/{characterId}")
     public ResponseEntity<SuccessResponse<?>> characterDetail(@PathVariable Long characterId) {
         CharacterDetailRes characterRes = characterService.getCharacterDetail(characterId);
         return ResponseEntity
@@ -51,15 +48,24 @@ public class CharacterController {
 
     }
 
-    @PutMapping("/owner/characters/{characterId}")
-    public ResponseEntity<SuccessResponse<?>> updateCharacter(@PathVariable Long characterId,
-                                                              @RequestBody @Valid UpdateCharacterReq updateCharacterReq,
+    @PutMapping("/owner/character/update")
+    public ResponseEntity<SuccessResponse<?>> updateCharacter(@RequestBody @Valid UpdateCharacterReq updateCharacterReq,
                                                               @AuthenticationPrincipal CustomUserDetails customUserDetails) {
 
-        UpdateCharacterRes updateCharacterRes = characterService.updateCharacter(characterId, updateCharacterReq, customUserDetails.getUsername());
+        UpdateCharacterRes updateCharacterRes = characterService.updateCharacter(updateCharacterReq, customUserDetails.getUsername());
 
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(SuccessResponse.ok(updateCharacterRes));
+    }
+
+    // 사장님 캐릭터 조회
+    @GetMapping("/owner/character")
+    public ResponseEntity<SuccessResponse<?>> getMyCharacter(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        MyCharacterRes myCharacterRes = characterService.getMyCharacter(customUserDetails.getUsername());
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(SuccessResponse.ok(myCharacterRes));
     }
 }

--- a/src/main/java/com/sixjeon/storey/domain/character/web/dto/MyCharacterRes.java
+++ b/src/main/java/com/sixjeon/storey/domain/character/web/dto/MyCharacterRes.java
@@ -1,0 +1,27 @@
+package com.sixjeon.storey.domain.character.web.dto;
+
+import lombok.Builder;
+
+@Builder
+public record MyCharacterRes(
+        boolean hasCharacter,
+        Long characterId,
+        String imageUrl,
+        String tagline,
+        String name,
+        String description,
+        String narrativeSummary
+) {
+    // 캐릭터가 없는 경우를 위한 정적 팩토리 메소드
+    public static MyCharacterRes noCharacter() {
+        return MyCharacterRes.builder()
+                .hasCharacter(false)
+                .characterId(null)
+                .imageUrl(null)
+                .tagline(null)
+                .name(null)
+                .description(null)
+                .narrativeSummary(null)
+                .build();
+    }
+}


### PR DESCRIPTION
## ✨ 작업 개요



<!-- 어떤 기능을 구현했는지 간단히 설명해주세요. -->

- 캐릭터 조회 기능 추가(사장)
- 캐릭터 상세 조회(사용자) 권한 부여
- api 엔드포인트 수정
- 캐릭터 수정 로직 버그 수정 

## 📌 관련 이슈



- close #55 



## 📄 작업 내용

- 캐릭터 상세 조회를 USER 권한으로 변경 (/user/characters/{id})
- 사장님용 내 캐릭터 조회 API 추가 (/owner/character)
- 캐릭터 수정 API를 PathVariable 없이 JWT 토큰 기반으로 변경 (/owner/character/update)
- MyCharacterRes DTO 추가 (hasCharacter 플래그로 캐릭터 존재 여부 확인)
- 보안 강화: JWT 토큰만으로 본인 캐릭터 식별
- API 일관성 개선: 권한별 엔드포인트 명확히 구분

